### PR TITLE
feat(decider, connector): poll new-app-cid events

### DIFF
--- a/src/aqua/decider.aqua
+++ b/src/aqua/decider.aqua
@@ -75,10 +75,23 @@ data WorkerArgs:
     -- IPFS API where the related CID resides
     ipfs: string
 
+data DealState:
+  from_block: string
+  app_cid: string
+
+service JsonDealState("json"):
+  parse(str: string) -> DealState
+
+func store_deal_state(spell_id: string, deal_id: string, state: DealState):
+    Spell spell_id
+    msg <- Json.stringify(state)
+    Spell.list_push_string(deal_id, msg)
+
 -- Stores info about created deals in the decider's KV
 data JoinedDeal:
   deal_id: string
   spell_id: string
+  worker_id: string
 
 service JsonJoinedDeal("json"):
   parse(str: string) -> JoinedDeal
@@ -164,51 +177,50 @@ func get_worker_settings(spell_id: string) ->  ?WorkerSettings, bool:
 -- The decider stores state of all processed deals:
 -- * `skipped` means that the decider decided not to join the deal and won't join it.
 -- * `joining` means that the deal started processing but wasn't processed 
-func mark_deal_joining(spell_id: string, deal_id: string):
-    Spell spell_id
-    Spell.set_string(deal_id, "joining")
-
-func mark_deal_joined(spell_id: string, deal_id: string):
-    Spell spell_id
-    Spell.set_string(deal_id, "joined")
-
-func mark_deal_skipped(spell_id: string, deal_id: string):
-    Spell spell_id
-    Spell.set_string(deal_id, "skipped")
-
-func get_deal_status(spell_id: string, deal_id: string) -> string:
-    Spell spell_id
-    status <- Spell.get_string(deal_id)
-    <- status.str
+-- func mark_deal_joining(spell_id: string, deal_id: string):
+--     Spell spell_id
+--     Spell.set_string(deal_id, "joining")
+-- 
+-- func mark_deal_joined(spell_id: string, deal_id: string):
+--     Spell spell_id
+--     Spell.set_string(deal_id, "joined")
+-- 
+-- func mark_deal_skipped(spell_id: string, deal_id: string):
+--     Spell spell_id
+--     Spell.set_string(deal_id, "skipped")
+-- 
+-- func get_deal_status(spell_id: string, deal_id: string) -> string:
+--     Spell spell_id
+--     status <- Spell.get_string(deal_id)
+--     <- status.str
 
 ---- The decider itself resides below
 
 -- TODO: implement it when we decide what the algo should be there
-func decide(deal: DealData) -> bool:
+func decide(deal: DealCreatedData) -> bool:
     <- true
 
 -- 
-func join_deal(spell_id: string, deal: DealData) -> bool:
+func join_deal(spell_id: string, deal: DealCreatedData) -> bool:
     settings, is_ok <- get_worker_settings(spell_id)
     status: *bool
     if is_ok == false:
         status <<- false
     else:
-        mark_deal_joining(spell_id, deal.deal_id)
         try:
             worker_id <- Worker.create(deal.deal_id)
             on worker_id:
                 args = WorkerArgs(deal_id = deal.deal_id, worker_def_cid = deal.app_cid, ipfs = settings!.worker_ipfs)
                 worker_spell_id <- PeerSpell.install(settings!.worker_script, args, settings!.worker_config)
                 log(spell_id, ["created worker for deal", deal.deal_id, "spell_id", worker_spell_id, "worker_id", worker_id])
-                mark_deal_joined(spell_id, deal.deal_id)
-                joined_deal = JoinedDeal(deal_id = deal.deal_id, spell_id = worker_spell_id)
+                joined_deal = JoinedDeal(deal_id = deal.deal_id, spell_id = worker_spell_id, worker_id = worker_id)
                 store_joined_deal(spell_id, joined_deal)
+                deal_state = DealState(from_block = "earliest", app_cid = deal.app_cid)
+                store_deal_state(spell_id, deal.deal_id, deal_state)
                 status <<- true
 
         catch e:
             log(spell_id, ["cannot create worker", deal.deal_id, e.message, "; skip"])
-            mark_deal_joined(spell_id, deal.deal_id)
             status <<- false
 
     <- status!
@@ -216,7 +228,6 @@ func join_deal(spell_id: string, deal: DealData) -> bool:
 func process_deal(spell_id: string, deal: DealCreated):
     if decide(deal.info) == false:
         log(spell_id, ["skipping deal for deal id", deal.info.deal_id, "from_block", deal.block_number])
-        mark_deal_skipped(spell_id, deal.info.deal_id)
     else:
         log(spell_id, ["joining the deal", deal.info.deal_id, "from_block", deal.block_number])
         is_ok <- join_deal(spell_id, deal.info)
@@ -224,11 +235,6 @@ func process_deal(spell_id: string, deal: DealCreated):
             log(spell_id, ["joined the deal", deal.info.deal_id])
         else:
             log(spell_id, ["couldn't join the deal", deal.info.deal_id])
-
--- To update the last seen from_block 
--- We store the last seen block to reduce the number of deals the poller provides us
-data Update:
-  from_block: string
 
 -- Data we need to poll new deals from aurora
 data AuroraInfo:
@@ -239,42 +245,65 @@ data AuroraInfo:
   -- Chain contract address
   address: string
 
-func main(spell_id: string, listener_id: string, info: AuroraInfo, from_block: string) -> Update: 
+func poll_deal_changes(spell_id: string, listener_id: string, net: string):
     FluenceAuroraConnector listener_id
-    update: *Update
+    Spell spell_id
+    -- Get a list of all known deals
+    list <- Spell.list_get_strings("joined_deals")
+    if list.success:
+        for str <- list.strings:
+            joined_deal <- JsonJoinedDeal.parse(str)
+            -- Get detailed state of the deal
+            deal_str, is_ok <- get_string(spell_id, joined_deal.deal_id)
+            if is_ok == false:
+                log(spell_id, ["found joined_deal, but not saved state", joined_deal.deal_id])
+            else:
+                deal_state <- JsonDealState.parse(deal_str!)
+                -- Find updates for the deals
+                deal_address <- Op.concat_strings("0x", joined_deal.deal_id)
+                result <- FluenceAuroraConnector.poll_deal_change(net, deal_address, deal_state.from_block)
+                if result.success == false:
+                    log(spell_id, ["can't retrieve deal changes", joined_deal.deal_id, deal_state.from_block])
+                else:
+                    -- Find how many changes are there
+                    number_of_changes <- OpExt.array_length(result.result)
+                    if number_of_changes > 0:
+                        log(spell_id, ["sending the latest update to the worker", joined_deal.worker_id, joined_deal.spell_id, "for deal", joined_deal.deal_id])
+                        -- Take the latest change to apply it.
+                        latest_deal_update = result.result[number_of_changes - 1]
+                        app_cid <- Json.stringify(latest_deal_update.info.app_cid)
+                        -- send to worker
+                        on joined_deal.worker_id:
+                            Spell joined_deal.spell_id
+                            Spell.set_string("worker_def_cid", app_cid)
+
+                        -- Update the deal
+                        new_deal_state = DealState(from_block = latest_deal_update.block_number, app_cid = latest_deal_update.info.app_cid)
+                        store_deal_state(spell_id, joined_deal.deal_id, new_deal_state)
+                    else:
+                        log(spell_id, ["no updated found for deal", joined_deal.deal_id])
+                        
+ 
+func poll_new_deals(spell_id: string, listener_id: string, info: AuroraInfo, from_block: string): 
+    FluenceAuroraConnector listener_id
+    Spell spell_id
 
     result <- FluenceAuroraConnector.poll_deals(info.net, info.address, from_block)
     if result.success == false:
         log_err(spell_id, result.error!)    
-        update <<- Update(from_block = from_block)
     else:
         for deal <- result.result:
             log(spell_id, ["found deal", deal.info.deal_id])
-            status <- get_deal_status(spell_id, deal.info.deal_id)
-            if status == "joined":
-                log(spell_id, ["skip joined deal", deal.info.deal_id])
+            if is_worker_created(spell_id, deal.info.deal_id):
+                log(spell_id, ["worker for deal", deal.info.deal_id, "already created"])
             else:
-                if status == "skipped":
-                    log(spell_id, ["skip skipped deal", deal.info.deal_id])
-                else:
-                    if status == "joining":
-                        log(spell_id, ["try to restore old deal in joining state", deal.info.deal_id])
-                        if is_worker_created(spell_id, deal.info.deal_id):
-                            log(spell_id, ["worker for the deal was already created, mark as joined", deal.info.deal_id])
-                            mark_deal_joined(spell_id, deal.info.deal_id)
-                        else:
-                            -- Do not recreate, just skip for now to avoid recreating workers.
-                            -- log(spell_id, ["no worker found, continue processing deal", deal.info.deal_id])
-                            -- process_deal(spell_id, deal)
-                            -- DEBUG:
-                            log(spell_id, ["worker was marked as joining already", deal.info.deal_id, "skip it"])
-                    else:
-                        log(spell_id, ["will process deal", deal.info.deal_id])
-                        process_deal(spell_id, deal)
-        deals_num <- OpExt.array_length(result.result)
-        if deals_num > 0:
-            new_from_block = result.result[deals_num - 1].block_number
-            update <<- Update(from_block = new_from_block)
-        else:
-            update <<- Update(from_block = from_block)
-    <- update!
+                process_deal(spell_id, deal)
+            new_from_block <- Json.stringify(deal.block_number)
+            Spell.set_string("from_block", new_from_block) 
+
+func main(spell_id: string, listener_id: string, info: AuroraInfo, from_block: string): 
+    -- Update existing deals
+    poll_deal_changes(spell_id, listener_id, info.net)
+
+    -- Find new deals and create workers
+    poll_new_deals(spell_id, listener_id, info, from_block)

--- a/src/aqua/decider.aqua
+++ b/src/aqua/decider.aqua
@@ -245,6 +245,24 @@ data AuroraInfo:
   -- Chain contract address
   address: string
 
+func need_update_from_block(listener_id: string, net: string, from_block: string, to_block: string) -> bool:
+    need_update: *bool
+    FluenceAuroraConnector listener_id
+    result <- FluenceAuroraConnector.latest_block_number(net)
+    if result.success:
+        latest_block = result.result
+        -- if to_block is less then latest block, move from_block to to_block
+        -- diff = result.result - to_block 
+        diff <- FluenceAuroraConnector.blocks_diff(to_block, latest_block)
+        RunConsoleAny.print(["diff", to_block, latest_block, diff])
+        if diff == 0:
+            need_update <<- false
+        else:
+            need_update <<- true
+    else:
+        need_update <<- false
+    <- need_update!
+
 func poll_deal_changes(spell_id: string, listener_id: string, net: string):
     FluenceAuroraConnector listener_id
     Spell spell_id
@@ -266,7 +284,7 @@ func poll_deal_changes(spell_id: string, listener_id: string, net: string):
                     log(spell_id, ["can't retrieve deal changes", joined_deal.deal_id, deal_state.from_block])
                 else:
                     -- Find how many changes are there
-                    number_of_changes <- OpExt.array_length(result.result)
+                    number_of_changes = result.result.length
                     if number_of_changes > 0:
                         log(spell_id, ["sending the latest update to the worker", joined_deal.worker_id, joined_deal.spell_id, "for deal", joined_deal.deal_id])
                         -- Take the latest change to apply it.
@@ -281,16 +299,19 @@ func poll_deal_changes(spell_id: string, listener_id: string, net: string):
                         new_deal_state = DealState(from_block = latest_deal_update.block_number, app_cid = latest_deal_update.info.app_cid)
                         store_deal_state(spell_id, joined_deal.deal_id, new_deal_state)
                     else:
-                        log(spell_id, ["no updated found for deal", joined_deal.deal_id])
-                        
- 
+                        need_update <- need_update_from_block(listener_id, net, deal_state.from_block, result.to_block)
+                        if need_update:
+                            new_deal_state2 = DealState(from_block = result.to_block, app_cid = deal_state.app_cid)
+                            store_deal_state(spell_id, joined_deal.deal_id, new_deal_state2)
+
+
 func poll_new_deals(spell_id: string, listener_id: string, info: AuroraInfo, from_block: string): 
     FluenceAuroraConnector listener_id
     Spell spell_id
 
     result <- FluenceAuroraConnector.poll_deals(info.net, info.address, from_block)
     if result.success == false:
-        log_err(spell_id, result.error!)    
+        log_err(spell_id, result.error!)
     else:
         for deal <- result.result:
             log(spell_id, ["found deal", deal.info.deal_id])
@@ -300,8 +321,14 @@ func poll_new_deals(spell_id: string, listener_id: string, info: AuroraInfo, fro
                 process_deal(spell_id, deal)
             new_from_block <- Json.stringify(deal.block_number)
             Spell.set_string("from_block", new_from_block) 
+        if result.result.length == 0:
+            need_update <- need_update_from_block(listener_id, info.net, from_block, result.to_block)
+            if need_update:
+                to_block_str <- Json.stringify(result.to_block)
+                Spell.set_string("from_block", to_block_str)
 
-func main(spell_id: string, listener_id: string, info: AuroraInfo, from_block: string): 
+    
+func main(spell_id: string, listener_id: string, info: AuroraInfo, from_block: string):
     -- Update existing deals
     poll_deal_changes(spell_id, listener_id, info.net)
 

--- a/src/aqua/fluence_aurora_connector.aqua
+++ b/src/aqua/fluence_aurora_connector.aqua
@@ -1,5 +1,9 @@
 module FluenceAuroraConnector declares *
 
+data BlockNumberResult:
+  success: bool
+  result: string
+
 data DealChangedData:
   app_cid: string
 
@@ -11,6 +15,7 @@ data DealChangedResult:
   error: []string
   success: bool
   result: []DealChanged
+  to_block: string
 
 data U256:
   bytes: []u8
@@ -35,6 +40,7 @@ data DealCreatedResult:
   error: []string
   success: bool
   result: []DealCreated
+  to_block: string
 
 data Net:
   name: string
@@ -49,6 +55,8 @@ data Env:
   events: []SupportedEvent
 
 service FluenceAuroraConnector:
+  blocks_diff(from: string, to: string) -> u64
   get_env() -> Env
+  latest_block_number(net: string) -> BlockNumberResult
   poll_deal_change(net: string, address: string, from_block: string) -> DealChangedResult
   poll_deals(net: string, address: string, from_block: string) -> DealCreatedResult

--- a/src/aqua/fluence_aurora_connector.aqua
+++ b/src/aqua/fluence_aurora_connector.aqua
@@ -1,9 +1,21 @@
 module FluenceAuroraConnector declares *
 
+data DealChangedData:
+  app_cid: string
+
+data DealChanged:
+  block_number: string
+  info: DealChangedData
+
+data DealChangedResult:
+  error: []string
+  success: bool
+  result: []DealChanged
+
 data U256:
   bytes: []u8
 
-data DealData:
+data DealCreatedData:
   deal_id: string
   payment_token: string
   price_per_epoch: U256
@@ -17,7 +29,7 @@ data DealData:
 
 data DealCreated:
   block_number: string
-  info: DealData
+  info: DealCreatedData
 
 data DealCreatedResult:
   error: []string
@@ -38,4 +50,5 @@ data Env:
 
 service FluenceAuroraConnector:
   get_env() -> Env
+  poll_deal_change(net: string, address: string, from_block: string) -> DealChangedResult
   poll_deals(net: string, address: string, from_block: string) -> DealCreatedResult

--- a/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/deal/changed_cid.rs
+++ b/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/deal/changed_cid.rs
@@ -1,0 +1,56 @@
+use super::*;
+use ethabi::param_type::ParamType;
+use marine_rs_sdk::marine;
+
+/// Corresponding Solidity type:
+/// ```solidity
+/// event NewAppCID(string appCID);
+/// ```
+#[derive(Debug)]
+#[marine]
+pub struct DealChangedData {
+    ///
+    app_cid: String,
+}
+
+#[marine]
+pub struct DealChanged {
+    block_number: String,
+    info: DealChangedData,
+}
+
+impl DealChanged {
+    pub const EVENT_NAME: &str = "NewAppCID";
+}
+
+impl ChainData for DealChangedData {
+    fn topic() -> String {
+        let sig = Self::signature();
+        let hash = ethabi::long_signature(DealChanged::EVENT_NAME, &sig);
+        format!("0x{}", hex::encode(hash.as_bytes()))
+    }
+
+    fn signature() -> Vec<ParamType> {
+        vec![
+            ParamType::String, // appCID
+        ]
+    }
+
+    /// Parse data from chain. Accepts data with and without "0x" prefix.
+    fn parse(data: &str) -> Result<DealChangedData, DealParseError> {
+        let data_tokens = parse_chain_data(data, Self::signature())?;
+        let deal_data: Option<DealChangedData> = try {
+            let app_cid = data_tokens[0].clone().into_string()?;
+            DealChangedData { app_cid }
+        };
+        deal_data.ok_or_else(|| {
+            DealParseError::InternalError("parsed data doesn't correspond expected signature")
+        })
+    }
+}
+
+impl ChainEvent<DealChangedData> for DealChanged {
+    fn new(block_number: String, info: DealChangedData) -> Self {
+        Self { block_number, info }
+    }
+}

--- a/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/deal/mod.rs
+++ b/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/deal/mod.rs
@@ -1,0 +1,69 @@
+pub mod changed_cid;
+pub mod created;
+
+use ethabi::param_type::ParamType;
+use ethabi::Token;
+use marine_rs_sdk::marine;
+use thiserror::Error;
+
+pub trait ChainEvent<ChainData> {
+    fn new(block_number: String, data: ChainData) -> Self;
+}
+
+pub trait ChainData {
+    fn signature() -> Vec<ParamType>;
+    fn parse(data: &str) -> Result<Self, DealParseError>
+    where
+        Self: Sized;
+    fn topic() -> String;
+}
+
+#[derive(Debug, Error)]
+pub enum DealParseError {
+    #[error(transparent)]
+    EthError(#[from] ethabi::Error),
+    #[error(transparent)]
+    HexError(#[from] hex::FromHexError),
+    #[error("internal error, please, contact developers: {0}")]
+    InternalError(&'static str),
+    #[error("empty data, nothing to parse")]
+    Empty,
+}
+
+/// Parse data from chain. Accepts data with and without "0x" prefix.
+pub(crate) fn parse_chain_data(
+    data: &str,
+    signature: Vec<ParamType>,
+) -> Result<Vec<Token>, DealParseError> {
+    let data = data.strip_prefix("0x").unwrap_or(data);
+    if data.is_empty() {
+        return Err(DealParseError::Empty);
+    }
+    let data = hex::decode(data)?;
+    Ok(ethabi::decode(&signature, &data)?)
+}
+
+#[derive(Debug, PartialEq)]
+#[marine]
+pub struct U256 {
+    bytes: Vec<u8>,
+}
+
+impl U256 {
+    pub fn from_bytes(bs: &[u8; 32]) -> Self {
+        U256 { bytes: bs.to_vec() }
+    }
+
+    pub fn to_eth(&self) -> ethabi::ethereum_types::U256 {
+        ethabi::ethereum_types::U256::from_little_endian(&self.bytes)
+    }
+
+    pub fn from_eth(num: ethabi::ethereum_types::U256) -> U256 {
+        let bytes = num
+            .0
+            .iter()
+            .flat_map(|x| x.to_le_bytes())
+            .collect::<Vec<_>>();
+        U256 { bytes }
+    }
+}

--- a/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/jsonrpc.rs
+++ b/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/jsonrpc.rs
@@ -43,6 +43,19 @@ impl<T> JsonRpcResp<T> {
     }
 }
 
+pub struct BlockNumberReq;
+
+impl BlockNumberReq {
+    pub fn to_jsonrpc() -> JsonRpcReq<Vec<()>> {
+        JsonRpcReq {
+            jsonrpc: JSON_RPC_VERSION.to_string(),
+            id: 0,
+            method: "eth_blockNumber".to_string(),
+            params: vec![],
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetLogsReq {

--- a/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/main.rs
+++ b/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/main.rs
@@ -11,9 +11,15 @@ use marine_rs_sdk::module_manifest;
 use marine_rs_sdk::WasmLoggerBuilder;
 
 use std::collections::HashMap;
+use thiserror::Error;
 
-use deal::*;
+use deal::changed_cid::*;
+use deal::created::*;
+use deal::ChainData;
+use deal::ChainEvent;
 use request::*;
+
+use jsonrpc::GetLogsResp;
 
 module_manifest!();
 
@@ -56,21 +62,37 @@ pub fn get_env() -> Env {
             url: url.to_string(),
         })
         .collect::<_>();
-    let events = vec![SupportedEvent {
-        name: DealCreated::EVENT_NAME.to_string(),
-        topic: DealCreated::topic(),
-    }];
+    let events = vec![
+        SupportedEvent {
+            name: DealCreated::EVENT_NAME.to_string(),
+            topic: DealCreatedData::topic(),
+        },
+        SupportedEvent {
+            name: DealChanged::EVENT_NAME.to_string(),
+            topic: DealChangedData::topic(),
+        },
+    ];
     Env { nets, events }
 }
 
 // Nets we allow to poll.
 fn nets() -> HashMap<&'static str, &'static str> {
     HashMap::from([
-        ("testnet", "https://endpoints.omniatech.io/v1/matic/mumbai/public"),
+        (
+            "testnet",
+            "https://endpoints.omniatech.io/v1/matic/mumbai/public",
+        ),
         ("aurora-testnet", "https://testnet.aurora.dev"),
         // Note: cool for debugging, but do we want to leave it here?
         ("local", "http://localhost:8545"),
     ])
+}
+
+fn get_url(net: &str) -> Result<String, String> {
+    nets()
+        .get(net)
+        .map(|x| String::from(*x))
+        .ok_or_else(|| format!("unknown net: {}", net))
 }
 
 #[marine]
@@ -101,60 +123,112 @@ impl DealCreatedResult {
 // TODO: How to set an upper limit for how many responses to return?
 //       Don't see this functionallity in eth_getLogs
 // TODO: need to restrict who can use this service to its spell.
+//
+// `net` -- network type to poll (right now it's possible to pass any URL for emergency cases)
+// `address` -- address of the deal contract
+// `from_block` -- from which block to poll deals
 #[marine]
 pub fn poll_deals(net: String, address: String, from_block: String) -> DealCreatedResult {
+    let result = poll(net, address, from_block, DealCreatedData::topic());
+    match result {
+        Err(err) => return DealCreatedResult::error(err.to_string()),
+        Ok(deals) => {
+            let changed_deals = parse_deals::<DealCreatedData, DealCreated>(deals);
+            DealCreatedResult::ok(changed_deals)
+        }
+    }
+}
+
+#[marine]
+pub struct DealChangedResult {
+    error: Vec<String>,
+    success: bool,
+    result: Vec<DealChanged>,
+}
+
+impl DealChangedResult {
+    fn ok(result: Vec<DealChanged>) -> Self {
+        Self {
+            success: true,
+            error: vec![],
+            result: result,
+        }
+    }
+
+    fn error(err_msg: String) -> Self {
+        Self {
+            success: false,
+            error: vec![err_msg],
+            result: vec![],
+        }
+    }
+}
+
+// `net` -- network type to poll (right now it's possible to pass any URL for emergency cases)
+// `address` -- address of the deal we are modifying
+// `from_block` -- from which block to poll deals
+#[marine]
+pub fn poll_deal_change(net: String, address: String, from_block: String) -> DealChangedResult {
+    let result = poll(net, address, from_block, DealChangedData::topic());
+    match result {
+        Err(err) => return DealChangedResult::error(err.to_string()),
+        Ok(deals) => {
+            let changed_deals = parse_deals::<DealChangedData, DealChanged>(deals);
+            DealChangedResult::ok(changed_deals)
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+enum Error {
+    #[error(transparent)]
+    RequestError(#[from] request::RequestError),
+    #[error(transparent)]
+    JsonRpcError(#[from] jsonrpc::JsonRpcError),
+}
+
+fn poll(
+    net: String,
+    address: String,
+    from_block: String,
+    topic: String,
+) -> Result<Vec<GetLogsResp>, Error> {
     let url = match get_url(&net) {
         Err(_err) => {
-
             // TODO: right now we allow to use URL directly for emergency cases.
-            // Would be nice to now
             // return DealCreatedResult::error(err);
             net
         }
         Ok(url) => url,
     };
-    log::debug!("sending request to {}", url);
-    let result = get_logs(url, address, vec![DealCreated::topic()], from_block);
-    let value = match result {
-        Err(err) => {
-            return DealCreatedResult::error(err.to_string());
-        }
-        Ok(value) => value,
-    };
-    log::debug!("request result: {:?}", value);
-    let deals = match value.get_result() {
-        Err(err) => return DealCreatedResult::error(err.to_string()),
-        Ok(deals) => deals,
-    };
 
-    let deals = deals
+    log::debug!("sending request to {}", url);
+    let value = get_logs(url, address, vec![topic], from_block)?;
+    log::debug!("request result: {:?}", value);
+    let deals = value.get_result()?;
+    Ok(deals)
+}
+
+fn parse_deals<U: ChainData, T: ChainEvent<U>>(deals: Vec<GetLogsResp>) -> Vec<T> {
+    deals
         .into_iter()
         .filter(|deal| !deal.removed)
         .filter_map(|deal| {
             log::debug!("Parse block {:?}", deal.block_number);
-            let data = parse_chain_deal_data(&deal.data);
+            let data = U::parse(&deal.data);
             match data {
                 Err(err) => {
                     // Here we ignore blocks we cannot parse.
                     // Is it okay? We can't send warning
-                    log::warn!(
+                    log::warn!(target: "connector",
                         "Cannot parse data of deal from block {}: {:?}",
                         deal.block_number,
                         err.to_string()
                     );
                     None
                 }
-                Ok(data) => Some(DealCreated::new(deal.block_number, data)),
+                Ok(data) => Some(T::new(deal.block_number, data)),
             }
         })
-        .collect();
-
-    DealCreatedResult::ok(deals)
-}
-
-fn get_url(net: &str) -> Result<String, String> {
-    nets()
-        .get(net)
-        .map(|x| String::from(*x))
-        .ok_or_else(|| format!("unknown net: {}", net))
+        .collect()
 }

--- a/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/main.rs
+++ b/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/main.rs
@@ -23,6 +23,14 @@ use jsonrpc::GetLogsResp;
 
 module_manifest!();
 
+#[derive(Debug, Error)]
+enum Error {
+    #[error(transparent)]
+    RequestError(#[from] request::RequestError),
+    #[error(transparent)]
+    JsonRpcError(#[from] jsonrpc::JsonRpcError),
+}
+
 pub fn main() {
     WasmLoggerBuilder::new().build().unwrap();
 }
@@ -78,8 +86,9 @@ pub fn get_env() -> Env {
 // Nets we allow to poll.
 fn nets() -> HashMap<&'static str, &'static str> {
     HashMap::from([
+        ("testnet", "https://aged-tiniest-scion.matic-testnet.quiknode.pro/08133c1e70a6ec1e7a75545a1254d85640a6251d/"),
         (
-            "testnet",
+            "polygon-testnet",
             "https://endpoints.omniatech.io/v1/matic/mumbai/public",
         ),
         ("aurora-testnet", "https://testnet.aurora.dev"),
@@ -95,19 +104,78 @@ fn get_url(net: &str) -> Result<String, String> {
         .ok_or_else(|| format!("unknown net: {}", net))
 }
 
+fn get_to_block(from_block: &str) -> String {
+    let from_block = from_block.trim_start_matches("0x");
+    let to_block = try {
+        let from_block = u64::from_str_radix(from_block, 16).ok()?;
+        from_block.checked_add(9999)?
+    };
+    match to_block {
+        Some(to_block) => format!("{:#x}", to_block),
+        None => "latest".to_string(),
+    }
+}
+
+#[marine]
+pub fn blocks_diff(from: String, to: String) -> u64 {
+    let diff: Option<u64> = try {
+        let from = from.trim_start_matches("0x");
+        let from = u64::from_str_radix(from, 16).ok()?;
+
+        let to = to.trim_start_matches("0x");
+        let to = u64::from_str_radix(to, 16).ok()?;
+
+        to.checked_sub(from)?
+    };
+    diff.unwrap_or(0)
+}
+
+#[marine]
+pub struct BlockNumberResult {
+    success: bool,
+    result: String,
+}
+
+#[marine]
+pub fn latest_block_number(net: String) -> BlockNumberResult {
+    let url = match get_url(&net) {
+        Err(_err) => {
+            // TODO: right now we allow to use URL directly for emergency cases.
+            // return DealCreatedResult::error(err);
+            net
+        }
+        Ok(url) => url,
+    };
+
+    let result: Result<String, Error> = try {
+        let result = get_block_number(url)?;
+        log::debug!("request result: {:?}", result);
+        result.get_result()?
+    };
+    match result {
+        Ok(result) => BlockNumberResult { success: true, result },
+        Err(err) => {
+            log::warn!("can't get block number: {}", err.to_string());
+            BlockNumberResult { success: false, result: String::new() }
+        }
+    }
+}
+
 #[marine]
 pub struct DealCreatedResult {
     error: Vec<String>,
     success: bool,
     result: Vec<DealCreated>,
+    to_block: String,
 }
 
 impl DealCreatedResult {
-    fn ok(result: Vec<DealCreated>) -> Self {
+    fn ok(result: Vec<DealCreated>, to_block: String) -> Self {
         Self {
             success: true,
             error: vec![],
-            result: result,
+            result,
+            to_block,
         }
     }
 
@@ -116,6 +184,7 @@ impl DealCreatedResult {
             success: false,
             error: vec![err_msg],
             result: vec![],
+            to_block: String::new(),
         }
     }
 }
@@ -129,12 +198,13 @@ impl DealCreatedResult {
 // `from_block` -- from which block to poll deals
 #[marine]
 pub fn poll_deals(net: String, address: String, from_block: String) -> DealCreatedResult {
-    let result = poll(net, address, from_block, DealCreatedData::topic());
+    let to_block = get_to_block(&from_block);
+    let result = poll(net, address, from_block, to_block.clone(), DealCreatedData::topic());
     match result {
         Err(err) => return DealCreatedResult::error(err.to_string()),
         Ok(deals) => {
             let changed_deals = parse_deals::<DealCreatedData, DealCreated>(deals);
-            DealCreatedResult::ok(changed_deals)
+            DealCreatedResult::ok(changed_deals, to_block)
         }
     }
 }
@@ -144,14 +214,16 @@ pub struct DealChangedResult {
     error: Vec<String>,
     success: bool,
     result: Vec<DealChanged>,
+    to_block: String,
 }
 
 impl DealChangedResult {
-    fn ok(result: Vec<DealChanged>) -> Self {
+    fn ok(result: Vec<DealChanged>, to_block: String) -> Self {
         Self {
             success: true,
             error: vec![],
-            result: result,
+            result,
+            to_block,
         }
     }
 
@@ -160,6 +232,7 @@ impl DealChangedResult {
             success: false,
             error: vec![err_msg],
             result: vec![],
+            to_block: String::new(),
         }
     }
 }
@@ -169,28 +242,22 @@ impl DealChangedResult {
 // `from_block` -- from which block to poll deals
 #[marine]
 pub fn poll_deal_change(net: String, address: String, from_block: String) -> DealChangedResult {
-    let result = poll(net, address, from_block, DealChangedData::topic());
+    let to_block = get_to_block(&from_block);
+    let result = poll(net, address, from_block, to_block.clone(), DealChangedData::topic());
     match result {
         Err(err) => return DealChangedResult::error(err.to_string()),
         Ok(deals) => {
             let changed_deals = parse_deals::<DealChangedData, DealChanged>(deals);
-            DealChangedResult::ok(changed_deals)
+            DealChangedResult::ok(changed_deals, to_block)
         }
     }
-}
-
-#[derive(Debug, Error)]
-enum Error {
-    #[error(transparent)]
-    RequestError(#[from] request::RequestError),
-    #[error(transparent)]
-    JsonRpcError(#[from] jsonrpc::JsonRpcError),
 }
 
 fn poll(
     net: String,
     address: String,
     from_block: String,
+    to_block: String,
     topic: String,
 ) -> Result<Vec<GetLogsResp>, Error> {
     let url = match get_url(&net) {
@@ -203,7 +270,7 @@ fn poll(
     };
 
     log::debug!("sending request to {}", url);
-    let value = get_logs(url, address, vec![topic], from_block)?;
+    let value = get_logs(url, address, vec![topic], from_block, to_block)?;
     log::debug!("request result: {:?}", value);
     let deals = value.get_result()?;
     Ok(deals)

--- a/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/request.rs
+++ b/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/request.rs
@@ -16,11 +16,37 @@ pub enum RequestError {
     OtherError(String),
 }
 
+pub fn get_block_number(
+    url: String,
+) -> Result<JsonRpcResp<String>, RequestError> {
+    use RequestError::*;
+
+    let req = json!(BlockNumberReq::to_jsonrpc());
+    let req = serde_json::to_string(&req).unwrap();
+    log::debug!("request: {}", req);
+    // Make a request
+    let result = curl_request(curl_params(url, req)).into_std();
+    let result = match result {
+        None => {
+            return Err(OtherError(
+                "curl output is not a valid UTF-8 string".to_string(),
+            ));
+        }
+        Some(Err(err)) => return Err(CurlError(err)),
+        Some(Ok(result)) => result,
+    };
+    match serde_json::from_str(&result) {
+        Err(err) => Err(ParseError(err, result)),
+        Ok(result) => Ok(result),
+    }
+}
+
 pub fn get_logs(
     url: String,
     address: String,
     topics: Vec<String>,
     from_block: String,
+    to_block: String,
 ) -> Result<JsonRpcResp<Vec<GetLogsResp>>, RequestError> {
     use RequestError::*;
 
@@ -29,7 +55,7 @@ pub fn get_logs(
         address,
         topics,
         from_block,
-        to_block: "latest".to_string(),
+        to_block,
     };
     let req = json!(req.to_jsonrpc());
     let req = serde_json::to_string(&req).unwrap();

--- a/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/request.rs
+++ b/src/services/fluence-aurora-connector/modules/fluence_aurora_connector/src/request.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub enum RequestError {
     #[error("`curl` returned error: {0}")]
     CurlError(String),
     #[error(
@@ -21,8 +21,8 @@ pub fn get_logs(
     address: String,
     topics: Vec<String>,
     from_block: String,
-) -> Result<JsonRpcResp<Vec<GetLogsResp>>, Error> {
-    use Error::*;
+) -> Result<JsonRpcResp<Vec<GetLogsResp>>, RequestError> {
+    use RequestError::*;
 
     // Create a JSON RPC request
     let req = GetLogsReq {


### PR DESCRIPTION
* Add polling for cid updates for joined deals
* Update `testnet` link once again to our archive node (ask Elshan what it means)
* Since there are restrictions on how many blocks we can retrieve with getLogs, I restricted how many blocks we can ask in one request (9999 -- one less than the restriction just in case ). To avoid stucking in the same fromBlock-toBlock forever, I added checks of what is the bigger block number, and shift fromBlock if the toBlock is less than the latest block AND if there are no deals in fromBlock-toBlock range.  