### PR TITLE
fix(decider): Fix decider monitoring deals

### DIFF
--- a/src/aqua/decider.aqua
+++ b/src/aqua/decider.aqua
@@ -325,7 +325,7 @@ func poll_new_deals(spell_id: string, listener_id: string, info: AuroraInfo, fro
             Spell.set_string("from_block", new_from_block) 
         -- If we found no deals, we check if need to move the from_block forward
         -- We need to do it in case if no deals were done in range of 10000 blocks
-        if result.result.length == 0:
+        if result.result.length > 1 == false:
             need_update <- need_update_from_block(listener_id, info.net, result.to_block)
             if need_update:
                 log(spell_id, ["updating outdated from_block: [previous from_block, new_from_block]", from_block, result.to_block])


### PR DESCRIPTION
The decider moves `from_block` if no deals are in the range, but there can be one already processed deal. 