### PR TITLE
fix: find latest block when from_block is latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install fluence-cli
         run: npm i -g @fluencelabs/cli@unstable

--- a/src/aqua/decider.aqua
+++ b/src/aqua/decider.aqua
@@ -322,8 +322,9 @@ func poll_new_deals(spell_id: string, info: AuroraInfo, from_block: string):
     log = (msg: []⊤):
         spell_log(spell_id, msg)
 
-    -- On the first iteration of the spell obtain the number of the latest block in the chain
-    -- And proccess the deals from now on ignoring deals from the past.
+    -- Obtain the number of the latest block in the chain on the first iteration
+    -- (therefore proccess the deals from now on ignoring deals from the past), or
+    -- when the from_block is "latest" (also can lead to ignoring some deals)
     from_block_init: *string
     counter <- get_counter(spell_id)
     is_first_iteration <- Compare.lte(counter, 1)

--- a/src/aqua/decider.aqua
+++ b/src/aqua/decider.aqua
@@ -5,6 +5,8 @@
 import "@fluencelabs/spell/api.aqua"
 import "@fluencelabs/spell/spell_service.aqua"
 import "@fluencelabs/aqua-lib/builtin.aqua"
+import "@fluencelabs/aqua-lib/binary.aqua"
+import "@fluencelabs/aqua-lib/math.aqua"
 import "services.aqua"
 
 -- Worker API
@@ -306,6 +308,15 @@ func get_counter(spell_id: string) -> u32:
         result <<- 0
     <- result!
 
+
+func eq(a: string, b: string) -> bool:
+   result: *bool
+   if a == b:
+      result <<- true
+   else:
+      result <<- false
+   <- result!
+
 func poll_new_deals(spell_id: string, info: AuroraInfo, from_block: string): 
     Spell spell_id
     log = (msg: []⊤):
@@ -315,7 +326,9 @@ func poll_new_deals(spell_id: string, info: AuroraInfo, from_block: string):
     -- And proccess the deals from now on ignoring deals from the past.
     from_block_init: *string
     counter <- get_counter(spell_id)
-    if counter > 1 == false:
+    is_first_iteration <- Compare.lte(counter, 1)
+    is_latest <- eq(from_block, "latest")
+    if or(is_first_iteration, is_latest):
         bnumber  <- FluenceAuroraConnector.latest_block_number(info.api_endpoint)
         if bnumber.success:
             log(["update from_block to the latest block: [init, new]", from_block, bnumber.result])


### PR DESCRIPTION
Update `from_block` to the latest block when `from_block == "latest"`. 

The motivation for this PR is to support updating the decider spell without redeploying it.

When `from_block` is "latest" new deals aren't found :shrug: 