### PR TITLE
fix(decider): use deal-removed state for polling the removed-from-provider event

### DIFF
--- a/.fluence/aqua-dependencies/package-lock.json
+++ b/.fluence/aqua-dependencies/package-lock.json
@@ -1,0 +1,84 @@
+{
+  "name": "aqua-dependencies",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@fluencelabs/aqua-ipfs": "0.5.28",
+        "@fluencelabs/aqua-lib": "0.9.0",
+        "@fluencelabs/installation-spell": "0.6.4",
+        "@fluencelabs/registry": "0.9.4",
+        "@fluencelabs/spell": "0.6.5"
+      }
+    },
+    "node_modules/@fluencelabs/aqua-ipfs": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@fluencelabs/aqua-ipfs/-/aqua-ipfs-0.5.28.tgz",
+      "integrity": "sha512-2OUnSc+si9ljqWIZeQB7mydMmiGDnk/82/bEwmT1Y50zZ8NFDYQctHR1qBMn0JPCnixKiGXAiez2w60NUGUZwA==",
+      "dependencies": {
+        "@fluencelabs/aqua-lib": "0.9.0"
+      }
+    },
+    "node_modules/@fluencelabs/aqua-lib": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@fluencelabs/aqua-lib/-/aqua-lib-0.9.0.tgz",
+      "integrity": "sha512-V0xhc0UXBF6kjfL9Y/agWGQuW+ie2zckj37KWv8Dq4teYuo9N94O4Ynm7XULWHaaWtbWvzFcDcc6nc9qG7gxcQ=="
+    },
+    "node_modules/@fluencelabs/installation-spell": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@fluencelabs/installation-spell/-/installation-spell-0.6.4.tgz",
+      "integrity": "sha512-0nocEHFtfXGTJCN23gx0dcYNZSEAmDWwlWlMwJF/zj1FXep3ro3IHGchs+siCJtiwqCFOeROOvcsrrWX+E2Egw==",
+      "dependencies": {
+        "@fluencelabs/aqua-ipfs": "0.5.28",
+        "@fluencelabs/aqua-lib": "0.9.0",
+        "@fluencelabs/spell": "0.6.4"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/@fluencelabs/installation-spell/node_modules/@fluencelabs/spell": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@fluencelabs/spell/-/spell-0.6.4.tgz",
+      "integrity": "sha512-y6gorixaReBZRgZDCMroqFm5h3COlYifccgE1BKgKMoDGb4kSf7n8rHi7Mwjp3cXpibCsYaXCCh16TzFHu/72A==",
+      "dependencies": {
+        "@fluencelabs/aqua-lib": "0.9.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/@fluencelabs/registry": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@fluencelabs/registry/-/registry-0.9.4.tgz",
+      "integrity": "sha512-7KK8sZSF+dGOZ0A87F5wUYRFlELpfhVAUQ/dfnGBi2GukELobTHf30BfFCcbkL0rWe/zrylIb4MX7czEl22UZA==",
+      "dependencies": {
+        "@fluencelabs/aqua-lib": "0.9.0",
+        "@fluencelabs/trust-graph": "0.4.10"
+      }
+    },
+    "node_modules/@fluencelabs/spell": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@fluencelabs/spell/-/spell-0.6.5.tgz",
+      "integrity": "sha512-UsJQ/aBt/zErdnwF7ik6MIH95EiPcmix/lcmYuro3Korrw45G4Y9VOxJknWxpwDwB+UsztbqcKT6AHTQ2dkw7A==",
+      "dependencies": {
+        "@fluencelabs/aqua-lib": "0.9.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/@fluencelabs/trust-graph": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@fluencelabs/trust-graph/-/trust-graph-0.4.10.tgz",
+      "integrity": "sha512-Ixo1ifQGhCxVMDNROE4w9Dn9k9TcnpHxKS+B/PmeAlpiWwhHDprfYXU7pq6HCYGzR/nJwIvAE9T6boQAcgiMqw==",
+      "dependencies": {
+        "@fluencelabs/aqua-lib": "^0.9.0"
+      }
+    }
+  }
+}

--- a/.fluence/aqua-dependencies/package.json
+++ b/.fluence/aqua-dependencies/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "@fluencelabs/aqua-ipfs": "0.5.28",
+    "@fluencelabs/installation-spell": "0.6.4",
+    "@fluencelabs/spell": "0.6.5",
+    "@fluencelabs/aqua-lib": "0.9.0",
+    "@fluencelabs/registry": "0.9.4"
+  }
+}

--- a/.fluence/schemas/env.json
+++ b/.fluence/schemas/env.json
@@ -24,5 +24,6 @@
   },
   "required": [
     "version"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/.fluence/schemas/fluence.json
+++ b/.fluence/schemas/fluence.json
@@ -88,7 +88,8 @@
                 }
               },
               "required": [],
-              "nullable": true
+              "nullable": true,
+              "additionalProperties": false
             },
             "properties": {
               "Module_name": {
@@ -161,7 +162,8 @@
                   }
                 },
                 "required": [],
-                "nullable": true
+                "nullable": true,
+                "additionalProperties": false
               }
             },
             "nullable": true,
@@ -170,7 +172,8 @@
         },
         "required": [
           "get"
-        ]
+        ],
+        "additionalProperties": false
       },
       "properties": {
         "Service_name": {
@@ -256,7 +259,8 @@
                   }
                 },
                 "required": [],
-                "nullable": true
+                "nullable": true,
+                "additionalProperties": false
               },
               "properties": {
                 "Module_name": {
@@ -329,7 +333,8 @@
                     }
                   },
                   "required": [],
-                  "nullable": true
+                  "nullable": true,
+                  "additionalProperties": false
                 }
               },
               "nullable": true,
@@ -338,7 +343,8 @@
           },
           "required": [
             "get"
-          ]
+          ],
+          "additionalProperties": false
         }
       },
       "required": [],
@@ -387,7 +393,8 @@
           }
         }
       },
-      "required": []
+      "required": [],
+      "additionalProperties": false
     },
     "aquaInputPath": {
       "type": "string",
@@ -437,7 +444,8 @@
             "minItems": 1
           }
         },
-        "required": []
+        "required": [],
+        "additionalProperties": false
       },
       "properties": {
         "workerName": {
@@ -469,7 +477,8 @@
               "minItems": 1
             }
           },
-          "required": []
+          "required": [],
+          "additionalProperties": false
         }
       },
       "required": []
@@ -498,22 +507,42 @@
             },
             "nullable": true
           },
-          "minWorkers": {
+          "targetWorkers": {
             "type": "number",
-            "description": "Required workers to activate the deal",
+            "description": "Max workers in the deal",
             "default": 1,
             "nullable": true,
             "minimum": 1
           },
-          "targetWorkers": {
+          "minWorkers": {
             "type": "number",
-            "description": "Max workers in the deal",
-            "default": 3,
+            "description": "Required workers to activate the deal. Matches target workers by default",
             "nullable": true,
             "minimum": 1
+          },
+          "maxWorkersPerProvider": {
+            "type": "number",
+            "description": "Max workers per provider. Matches target workers by default",
+            "nullable": true,
+            "minimum": 1
+          },
+          "pricePerWorkerEpoch": {
+            "type": "number",
+            "description": "Price per worker epoch in FL. This number is multiplied by 10^18",
+            "default": 0.1,
+            "nullable": true,
+            "minimum": 1e-18
+          },
+          "collateralPerWorker": {
+            "type": "number",
+            "description": "Collateral per worker in FL. This number is multiplied by 10^18",
+            "default": 1,
+            "nullable": true,
+            "minimum": 1e-18
           }
         },
-        "required": []
+        "required": [],
+        "additionalProperties": false
       },
       "properties": {
         "dealName": {
@@ -536,22 +565,42 @@
               },
               "nullable": true
             },
-            "minWorkers": {
+            "targetWorkers": {
               "type": "number",
-              "description": "Required workers to activate the deal",
+              "description": "Max workers in the deal",
               "default": 1,
               "nullable": true,
               "minimum": 1
             },
-            "targetWorkers": {
+            "minWorkers": {
               "type": "number",
-              "description": "Max workers in the deal",
-              "default": 3,
+              "description": "Required workers to activate the deal. Matches target workers by default",
               "nullable": true,
               "minimum": 1
+            },
+            "maxWorkersPerProvider": {
+              "type": "number",
+              "description": "Max workers per provider. Matches target workers by default",
+              "nullable": true,
+              "minimum": 1
+            },
+            "pricePerWorkerEpoch": {
+              "type": "number",
+              "description": "Price per worker epoch in FL. This number is multiplied by 10^18",
+              "default": 0.1,
+              "nullable": true,
+              "minimum": 1e-18
+            },
+            "collateralPerWorker": {
+              "type": "number",
+              "description": "Collateral per worker in FL. This number is multiplied by 10^18",
+              "default": 1,
+              "nullable": true,
+              "minimum": 1e-18
             }
           },
-          "required": []
+          "required": [],
+          "additionalProperties": false
         }
       },
       "required": []
@@ -589,6 +638,7 @@
           },
           "clock": {
             "type": "object",
+            "additionalProperties": false,
             "nullable": true,
             "description": "Trigger the spell execution periodically. If you want to disable this property by overriding it in fluence.yaml - pass empty config for it like this: `clock: {}`",
             "properties": {
@@ -629,7 +679,8 @@
         },
         "required": [
           "get"
-        ]
+        ],
+        "additionalProperties": false
       },
       "properties": {
         "Spell_name": {
@@ -661,6 +712,7 @@
             },
             "clock": {
               "type": "object",
+              "additionalProperties": false,
               "nullable": true,
               "description": "Trigger the spell execution periodically. If you want to disable this property by overriding it in fluence.yaml - pass empty config for it like this: `clock: {}`",
               "properties": {
@@ -701,7 +753,8 @@
           },
           "required": [
             "get"
-          ]
+          ],
+          "additionalProperties": false
         }
       },
       "required": []
@@ -757,7 +810,8 @@
       "required": [
         "contractsEnv",
         "relays"
-      ]
+      ],
+      "additionalProperties": false
     },
     "defaultSecretKeyName": {
       "description": "Secret key with this name will be used by default by js-client inside CLI to run Aqua code",
@@ -775,5 +829,6 @@
   ],
   "$id": "https://fluence.dev/schemas/fluence.yaml",
   "title": "fluence.yaml",
-  "description": "Defines Fluence Project, most importantly - what exactly you want to deploy and how. You can use `fluence init` command to generate a template for new Fluence project"
+  "description": "Defines Fluence Project, most importantly - what exactly you want to deploy and how. You can use `fluence init` command to generate a template for new Fluence project",
+  "additionalProperties": false
 }

--- a/.fluence/schemas/module.json
+++ b/.fluence/schemas/module.json
@@ -86,6 +86,7 @@
       "const": 0
     }
   },
+  "additionalProperties": false,
   "required": [
     "version",
     "name"

--- a/.fluence/schemas/service.json
+++ b/.fluence/schemas/service.json
@@ -86,7 +86,8 @@
         },
         "required": [
           "get"
-        ]
+        ],
+        "additionalProperties": false
       },
       "properties": {
         "facade": {
@@ -163,7 +164,8 @@
           },
           "required": [
             "get"
-          ]
+          ],
+          "additionalProperties": false
         },
         "Other_module_name": {
           "type": "object",
@@ -239,7 +241,8 @@
           },
           "required": [
             "get"
-          ]
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
@@ -255,5 +258,6 @@
     "version",
     "name",
     "modules"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/.fluence/schemas/workers.json
+++ b/.fluence/schemas/workers.json
@@ -1,203 +1,1135 @@
 {
   "$id": "https://fluence.dev/schemas/workers.yaml",
   "title": "workers.yaml",
-  "type": "object",
   "description": "A result of app deployment. This file is created automatically after successful deployment using `fluence workers deploy` command",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version"
+  ],
   "properties": {
     "version": {
       "type": "number",
-      "const": 0
+      "const": 1,
+      "description": "Config version"
     },
     "deals": {
       "type": "object",
-      "description": "A map of created deals",
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "definition": {
-            "type": "string"
-          },
-          "timestamp": {
-            "type": "string",
-            "description": "ISO timestamp of the time when the worker was deployed"
-          },
-          "dealId": {
-            "type": "string"
-          },
-          "dealIdOriginal": {
-            "type": "string"
-          },
-          "chainNetwork": {
-            "type": "string",
-            "enum": [
-              "kras",
-              "testnet",
-              "stage",
-              "local"
-            ]
-          },
-          "chainNetworkId": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "timestamp",
-          "definition",
-          "dealId",
-          "dealIdOriginal",
-          "chainNetwork",
-          "chainNetworkId"
-        ]
-      },
-      "properties": {
-        "Worker_deployed_using_deals": {
-          "type": "object",
-          "properties": {
-            "definition": {
-              "type": "string"
-            },
-            "timestamp": {
-              "type": "string",
-              "description": "ISO timestamp of the time when the worker was deployed"
-            },
-            "dealId": {
-              "type": "string"
-            },
-            "dealIdOriginal": {
-              "type": "string"
-            },
-            "chainNetwork": {
-              "type": "string",
-              "enum": [
-                "kras",
-                "testnet",
-                "stage",
-                "local"
-              ]
-            },
-            "chainNetworkId": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "timestamp",
-            "definition",
-            "dealId",
-            "dealIdOriginal",
-            "chainNetwork",
-            "chainNetworkId"
-          ]
-        }
-      },
+      "description": "Info about deals created when deploying workers that is stored by environment that you deployed to",
+      "additionalProperties": false,
+      "nullable": true,
       "required": [],
-      "nullable": true
-    },
-    "hosts": {
-      "type": "object",
-      "description": "A map of deployed workers",
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "definition": {
-            "type": "string"
+      "properties": {
+        "custom": {
+          "type": "object",
+          "description": "A map of created deals",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dealId": {
+                "type": "string",
+                "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+              },
+              "dealIdOriginal": {
+                "type": "string",
+                "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+              },
+              "chainNetwork": {
+                "type": "string",
+                "enum": [
+                  "kras",
+                  "testnet",
+                  "stage",
+                  "local"
+                ],
+                "description": "Blockchain network name that was used when deploying workers"
+              },
+              "chainNetworkId": {
+                "type": "number",
+                "description": "Blockchain network id that was used when deploying workers"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "dealId",
+              "dealIdOriginal",
+              "chainNetwork",
+              "chainNetworkId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
           },
-          "timestamp": {
-            "type": "string",
-            "description": "ISO timestamp of the time when the worker was deployed"
-          },
-          "dummyDealId": {
-            "type": "string"
-          },
-          "installation_spells": {
-            "type": "array",
-            "description": "A list of installation spells",
-            "items": {
+          "properties": {
+            "Worker_deployed_using_deals": {
               "type": "object",
               "properties": {
-                "host_id": {
-                  "type": "string"
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
                 },
-                "spell_id": {
-                  "type": "string"
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
                 },
-                "worker_id": {
-                  "type": "string"
+                "dealId": {
+                  "type": "string",
+                  "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+                },
+                "dealIdOriginal": {
+                  "type": "string",
+                  "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+                },
+                "chainNetwork": {
+                  "type": "string",
+                  "enum": [
+                    "kras",
+                    "testnet",
+                    "stage",
+                    "local"
+                  ],
+                  "description": "Blockchain network name that was used when deploying workers"
+                },
+                "chainNetworkId": {
+                  "type": "number",
+                  "description": "Blockchain network id that was used when deploying workers"
                 }
               },
               "required": [
-                "host_id",
-                "spell_id",
-                "worker_id"
-              ]
+                "timestamp",
+                "definition",
+                "dealId",
+                "dealIdOriginal",
+                "chainNetwork",
+                "chainNetworkId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
             }
           },
-          "relayId": {
-            "type": "string"
-          }
+          "required": [],
+          "nullable": true
         },
-        "required": [
-          "timestamp",
-          "definition",
-          "installation_spells",
-          "relayId",
-          "dummyDealId"
-        ]
-      },
-      "properties": {
-        "Worker_deployed_using_direct_hosting": {
+        "testnet": {
           "type": "object",
-          "properties": {
-            "definition": {
-              "type": "string"
-            },
-            "timestamp": {
-              "type": "string",
-              "description": "ISO timestamp of the time when the worker was deployed"
-            },
-            "dummyDealId": {
-              "type": "string"
-            },
-            "installation_spells": {
-              "type": "array",
-              "description": "A list of installation spells",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "host_id": {
-                    "type": "string"
-                  },
-                  "spell_id": {
-                    "type": "string"
-                  },
-                  "worker_id": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "host_id",
-                  "spell_id",
-                  "worker_id"
-                ]
+          "description": "A map of created deals",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dealId": {
+                "type": "string",
+                "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+              },
+              "dealIdOriginal": {
+                "type": "string",
+                "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+              },
+              "chainNetwork": {
+                "type": "string",
+                "enum": [
+                  "kras",
+                  "testnet",
+                  "stage",
+                  "local"
+                ],
+                "description": "Blockchain network name that was used when deploying workers"
+              },
+              "chainNetworkId": {
+                "type": "number",
+                "description": "Blockchain network id that was used when deploying workers"
               }
             },
-            "relayId": {
-              "type": "string"
+            "required": [
+              "timestamp",
+              "definition",
+              "dealId",
+              "dealIdOriginal",
+              "chainNetwork",
+              "chainNetworkId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_deals": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dealId": {
+                  "type": "string",
+                  "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+                },
+                "dealIdOriginal": {
+                  "type": "string",
+                  "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+                },
+                "chainNetwork": {
+                  "type": "string",
+                  "enum": [
+                    "kras",
+                    "testnet",
+                    "stage",
+                    "local"
+                  ],
+                  "description": "Blockchain network name that was used when deploying workers"
+                },
+                "chainNetworkId": {
+                  "type": "number",
+                  "description": "Blockchain network id that was used when deploying workers"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "dealId",
+                "dealIdOriginal",
+                "chainNetwork",
+                "chainNetworkId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
             }
           },
-          "required": [
-            "timestamp",
-            "definition",
-            "installation_spells",
-            "relayId",
-            "dummyDealId"
-          ]
+          "required": [],
+          "nullable": true
+        },
+        "kras": {
+          "type": "object",
+          "description": "A map of created deals",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dealId": {
+                "type": "string",
+                "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+              },
+              "dealIdOriginal": {
+                "type": "string",
+                "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+              },
+              "chainNetwork": {
+                "type": "string",
+                "enum": [
+                  "kras",
+                  "testnet",
+                  "stage",
+                  "local"
+                ],
+                "description": "Blockchain network name that was used when deploying workers"
+              },
+              "chainNetworkId": {
+                "type": "number",
+                "description": "Blockchain network id that was used when deploying workers"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "dealId",
+              "dealIdOriginal",
+              "chainNetwork",
+              "chainNetworkId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_deals": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dealId": {
+                  "type": "string",
+                  "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+                },
+                "dealIdOriginal": {
+                  "type": "string",
+                  "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+                },
+                "chainNetwork": {
+                  "type": "string",
+                  "enum": [
+                    "kras",
+                    "testnet",
+                    "stage",
+                    "local"
+                  ],
+                  "description": "Blockchain network name that was used when deploying workers"
+                },
+                "chainNetworkId": {
+                  "type": "number",
+                  "description": "Blockchain network id that was used when deploying workers"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "dealId",
+                "dealIdOriginal",
+                "chainNetwork",
+                "chainNetworkId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
+            }
+          },
+          "required": [],
+          "nullable": true
+        },
+        "local": {
+          "type": "object",
+          "description": "A map of created deals",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dealId": {
+                "type": "string",
+                "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+              },
+              "dealIdOriginal": {
+                "type": "string",
+                "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+              },
+              "chainNetwork": {
+                "type": "string",
+                "enum": [
+                  "kras",
+                  "testnet",
+                  "stage",
+                  "local"
+                ],
+                "description": "Blockchain network name that was used when deploying workers"
+              },
+              "chainNetworkId": {
+                "type": "number",
+                "description": "Blockchain network id that was used when deploying workers"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "dealId",
+              "dealIdOriginal",
+              "chainNetwork",
+              "chainNetworkId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_deals": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dealId": {
+                  "type": "string",
+                  "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+                },
+                "dealIdOriginal": {
+                  "type": "string",
+                  "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+                },
+                "chainNetwork": {
+                  "type": "string",
+                  "enum": [
+                    "kras",
+                    "testnet",
+                    "stage",
+                    "local"
+                  ],
+                  "description": "Blockchain network name that was used when deploying workers"
+                },
+                "chainNetworkId": {
+                  "type": "number",
+                  "description": "Blockchain network id that was used when deploying workers"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "dealId",
+                "dealIdOriginal",
+                "chainNetwork",
+                "chainNetworkId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
+            }
+          },
+          "required": [],
+          "nullable": true
+        },
+        "stage": {
+          "type": "object",
+          "description": "A map of created deals",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dealId": {
+                "type": "string",
+                "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+              },
+              "dealIdOriginal": {
+                "type": "string",
+                "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+              },
+              "chainNetwork": {
+                "type": "string",
+                "enum": [
+                  "kras",
+                  "testnet",
+                  "stage",
+                  "local"
+                ],
+                "description": "Blockchain network name that was used when deploying workers"
+              },
+              "chainNetworkId": {
+                "type": "number",
+                "description": "Blockchain network id that was used when deploying workers"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "dealId",
+              "dealIdOriginal",
+              "chainNetwork",
+              "chainNetworkId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_deals": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dealId": {
+                  "type": "string",
+                  "description": "Lowercased version of dealIdOriginal without 0x prefix. Currently unused. Was previously used to resolve workers in aqua"
+                },
+                "dealIdOriginal": {
+                  "type": "string",
+                  "description": "Blockchain transaction id that you get when deploy workers. Can be used in aqua to get worker and host ids. Check out example in the aqua generated in the default template"
+                },
+                "chainNetwork": {
+                  "type": "string",
+                  "enum": [
+                    "kras",
+                    "testnet",
+                    "stage",
+                    "local"
+                  ],
+                  "description": "Blockchain network name that was used when deploying workers"
+                },
+                "chainNetworkId": {
+                  "type": "number",
+                  "description": "Blockchain network id that was used when deploying workers"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "dealId",
+                "dealIdOriginal",
+                "chainNetwork",
+                "chainNetworkId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your deployment, including, most importantly, deal id, that can be used to resolve workers in aqua"
+            }
+          },
+          "required": [],
+          "nullable": true
         }
-      },
+      }
+    },
+    "hosts": {
+      "description": "Info about directly deployed workers that is stored by environment that you deployed to",
+      "type": "object",
+      "additionalProperties": false,
+      "nullable": true,
       "required": [],
-      "nullable": true
+      "properties": {
+        "custom": {
+          "type": "object",
+          "description": "A map of directly deployed workers",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dummyDealId": {
+                "type": "string",
+                "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+              },
+              "installation_spells": {
+                "type": "array",
+                "description": "A list of installation spells",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "host_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    },
+                    "spell_id": {
+                      "type": "string",
+                      "description": "id of the installation spell, can be used to e.g. print spell logs"
+                    },
+                    "worker_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    }
+                  },
+                  "required": [
+                    "host_id",
+                    "spell_id",
+                    "worker_id"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "relayId": {
+                "type": "string",
+                "description": "relay peer id that was used when deploying"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "installation_spells",
+              "relayId",
+              "dummyDealId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_direct_hosting": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dummyDealId": {
+                  "type": "string",
+                  "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+                },
+                "installation_spells": {
+                  "type": "array",
+                  "description": "A list of installation spells",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "host_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      },
+                      "spell_id": {
+                        "type": "string",
+                        "description": "id of the installation spell, can be used to e.g. print spell logs"
+                      },
+                      "worker_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      }
+                    },
+                    "required": [
+                      "host_id",
+                      "spell_id",
+                      "worker_id"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "relayId": {
+                  "type": "string",
+                  "description": "relay peer id that was used when deploying"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "installation_spells",
+                "relayId",
+                "dummyDealId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+            }
+          },
+          "required": [],
+          "nullable": true
+        },
+        "testnet": {
+          "type": "object",
+          "description": "A map of directly deployed workers",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dummyDealId": {
+                "type": "string",
+                "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+              },
+              "installation_spells": {
+                "type": "array",
+                "description": "A list of installation spells",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "host_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    },
+                    "spell_id": {
+                      "type": "string",
+                      "description": "id of the installation spell, can be used to e.g. print spell logs"
+                    },
+                    "worker_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    }
+                  },
+                  "required": [
+                    "host_id",
+                    "spell_id",
+                    "worker_id"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "relayId": {
+                "type": "string",
+                "description": "relay peer id that was used when deploying"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "installation_spells",
+              "relayId",
+              "dummyDealId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_direct_hosting": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dummyDealId": {
+                  "type": "string",
+                  "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+                },
+                "installation_spells": {
+                  "type": "array",
+                  "description": "A list of installation spells",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "host_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      },
+                      "spell_id": {
+                        "type": "string",
+                        "description": "id of the installation spell, can be used to e.g. print spell logs"
+                      },
+                      "worker_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      }
+                    },
+                    "required": [
+                      "host_id",
+                      "spell_id",
+                      "worker_id"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "relayId": {
+                  "type": "string",
+                  "description": "relay peer id that was used when deploying"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "installation_spells",
+                "relayId",
+                "dummyDealId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+            }
+          },
+          "required": [],
+          "nullable": true
+        },
+        "kras": {
+          "type": "object",
+          "description": "A map of directly deployed workers",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dummyDealId": {
+                "type": "string",
+                "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+              },
+              "installation_spells": {
+                "type": "array",
+                "description": "A list of installation spells",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "host_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    },
+                    "spell_id": {
+                      "type": "string",
+                      "description": "id of the installation spell, can be used to e.g. print spell logs"
+                    },
+                    "worker_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    }
+                  },
+                  "required": [
+                    "host_id",
+                    "spell_id",
+                    "worker_id"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "relayId": {
+                "type": "string",
+                "description": "relay peer id that was used when deploying"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "installation_spells",
+              "relayId",
+              "dummyDealId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_direct_hosting": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dummyDealId": {
+                  "type": "string",
+                  "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+                },
+                "installation_spells": {
+                  "type": "array",
+                  "description": "A list of installation spells",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "host_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      },
+                      "spell_id": {
+                        "type": "string",
+                        "description": "id of the installation spell, can be used to e.g. print spell logs"
+                      },
+                      "worker_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      }
+                    },
+                    "required": [
+                      "host_id",
+                      "spell_id",
+                      "worker_id"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "relayId": {
+                  "type": "string",
+                  "description": "relay peer id that was used when deploying"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "installation_spells",
+                "relayId",
+                "dummyDealId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+            }
+          },
+          "required": [],
+          "nullable": true
+        },
+        "local": {
+          "type": "object",
+          "description": "A map of directly deployed workers",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dummyDealId": {
+                "type": "string",
+                "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+              },
+              "installation_spells": {
+                "type": "array",
+                "description": "A list of installation spells",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "host_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    },
+                    "spell_id": {
+                      "type": "string",
+                      "description": "id of the installation spell, can be used to e.g. print spell logs"
+                    },
+                    "worker_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    }
+                  },
+                  "required": [
+                    "host_id",
+                    "spell_id",
+                    "worker_id"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "relayId": {
+                "type": "string",
+                "description": "relay peer id that was used when deploying"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "installation_spells",
+              "relayId",
+              "dummyDealId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_direct_hosting": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dummyDealId": {
+                  "type": "string",
+                  "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+                },
+                "installation_spells": {
+                  "type": "array",
+                  "description": "A list of installation spells",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "host_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      },
+                      "spell_id": {
+                        "type": "string",
+                        "description": "id of the installation spell, can be used to e.g. print spell logs"
+                      },
+                      "worker_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      }
+                    },
+                    "required": [
+                      "host_id",
+                      "spell_id",
+                      "worker_id"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "relayId": {
+                  "type": "string",
+                  "description": "relay peer id that was used when deploying"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "installation_spells",
+                "relayId",
+                "dummyDealId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+            }
+          },
+          "required": [],
+          "nullable": true
+        },
+        "stage": {
+          "type": "object",
+          "description": "A map of directly deployed workers",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+              },
+              "timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the time when the worker was deployed"
+              },
+              "dummyDealId": {
+                "type": "string",
+                "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+              },
+              "installation_spells": {
+                "type": "array",
+                "description": "A list of installation spells",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "host_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    },
+                    "spell_id": {
+                      "type": "string",
+                      "description": "id of the installation spell, can be used to e.g. print spell logs"
+                    },
+                    "worker_id": {
+                      "type": "string",
+                      "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                    }
+                  },
+                  "required": [
+                    "host_id",
+                    "spell_id",
+                    "worker_id"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "relayId": {
+                "type": "string",
+                "description": "relay peer id that was used when deploying"
+              }
+            },
+            "required": [
+              "timestamp",
+              "definition",
+              "installation_spells",
+              "relayId",
+              "dummyDealId"
+            ],
+            "additionalProperties": false,
+            "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+          },
+          "properties": {
+            "Worker_deployed_using_direct_hosting": {
+              "type": "object",
+              "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "CID of uploaded to IPFS App Definition, which contains the data about everything that you are trying to deploy, including spells, service and module configs and CIDs for service wasms"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "description": "ISO timestamp of the time when the worker was deployed"
+                },
+                "dummyDealId": {
+                  "type": "string",
+                  "description": "random string generated by CLI, used in Nox. You can get worker id from it"
+                },
+                "installation_spells": {
+                  "type": "array",
+                  "description": "A list of installation spells",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "host_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      },
+                      "spell_id": {
+                        "type": "string",
+                        "description": "id of the installation spell, can be used to e.g. print spell logs"
+                      },
+                      "worker_id": {
+                        "type": "string",
+                        "description": "Can be used to access worker in aqua: `on s.workerId via s.hostId`"
+                      }
+                    },
+                    "required": [
+                      "host_id",
+                      "spell_id",
+                      "worker_id"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "relayId": {
+                  "type": "string",
+                  "description": "relay peer id that was used when deploying"
+                }
+              },
+              "required": [
+                "timestamp",
+                "definition",
+                "installation_spells",
+                "relayId",
+                "dummyDealId"
+              ],
+              "additionalProperties": false,
+              "description": "Contains data related to your direct deployment. Most importantly, it contains ids in installation_spells property that can be used to resolve workers in aqua"
+            }
+          },
+          "required": [],
+          "nullable": true
+        }
+      }
     }
-  },
-  "required": [
-    "version"
-  ]
+  }
 }

--- a/.fluence/workers.yaml
+++ b/.fluence/workers.yaml
@@ -4,7 +4,7 @@
 # This file is updated automatically after successful deployment using `fluence workers deploy` command
 
 # config version
-version: 0
+version: 1
 
 # # A map of created deals
 # deals:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1222,6 +1223,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,17 +1577,17 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686e73aff5e23efbb99bc85340ea6fd8686986aa7b283a881ba182cfca535ca9"
+checksum = "999ec70441b2fb35355076726a6bc466c932e9bdc66f6a11c6c0aa17c7ab9be0"
 dependencies = [
  "bs58",
- "log",
+ "hkdf",
  "multihash 0.19.1",
  "quick-protobuf",
- "rand",
  "sha2",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2609,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2716,6 +2735,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"

--- a/fluence.yaml
+++ b/fluence.yaml
@@ -12,8 +12,11 @@ dependencies:
   npm:
     "@fluencelabs/aqua-ipfs": 0.5.28
     "@fluencelabs/installation-spell": 0.6.4
-    "@fluencelabs/spell": 0.6.4
+    "@fluencelabs/spell": 0.6.5
     "@fluencelabs/aqua-lib": 0.9.0
+  cargo:
+    marine: 0.14.0
+    mrepl: 0.21.3
 
 # Path to the aqua file or directory with aqua files that you want to compile by default.
 # Must be relative to the project root dir

--- a/fluence.yaml
+++ b/fluence.yaml
@@ -14,6 +14,7 @@ dependencies:
     "@fluencelabs/installation-spell": 0.6.4
     "@fluencelabs/spell": 0.6.5
     "@fluencelabs/aqua-lib": 0.9.0
+    "@fluencelabs/registry": 0.9.4
   cargo:
     marine: 0.14.0
     mrepl: 0.21.3

--- a/src/aqua/chain/changed_deals.aqua
+++ b/src/aqua/chain/changed_deals.aqua
@@ -25,7 +25,7 @@ func make_change_reqs(spell_id: SpellId, deals: []JoinedDeal) -> []DealChangesRe
         deal_updates: *DealChangesReq
         for joined_deal <- deals:
             deal_id = joined_deal.deal_id
-            deal_state <- get_deal_state(spell_id, deal_id, deal_id)
+            deal_state <- get_deal_state(spell_id, deal_id)
             if deal_state != nil:
                 deal_info = DealInfo(deal_id = deal_id, worker_id = joined_deal.worker_id)
                 requests <<- DealChangesReq(deal_info = deal_info, left_boundary = deal_state!.left_boundary)

--- a/src/aqua/chain/changed_deals.aqua
+++ b/src/aqua/chain/changed_deals.aqua
@@ -25,7 +25,7 @@ func make_change_reqs(spell_id: SpellId, deals: []JoinedDeal) -> []DealChangesRe
         deal_updates: *DealChangesReq
         for joined_deal <- deals:
             deal_id = joined_deal.deal_id
-            deal_state <- get_deal_state(spell_id, deal_id)
+            deal_state <- get_deal_state(spell_id, deal_id, deal_id)
             if deal_state != nil:
                 deal_info = DealInfo(deal_id = deal_id, worker_id = joined_deal.worker_id)
                 requests <<- DealChangesReq(deal_info = deal_info, left_boundary = deal_state!.left_boundary)

--- a/src/aqua/chain/deal_peer_removed.aqua
+++ b/src/aqua/chain/deal_peer_removed.aqua
@@ -26,9 +26,10 @@ func poll_deal_peer_removed(spell_id: SpellId, api_endpoint: string, latest_bloc
                 reqs <<- DealPeerRemovedReq(deal_id = deal_id, left_boundary = state!.left_boundary) 
 
         if reqs != nil:
+            spell_log(spell_id, ["find if deals are removed from the provider for", reqs.length, "deals"])
             result <- ChainConnector.poll_deal_peer_removed_batch(api_endpoint, reqs)
             if !result.success:
-                spell_log(spell_id, ["can't find if deals were removed from provider:", result.error])
+                spell_log(spell_id, ["can't find if deals are removed from provider:", result.error])
             else:
                 for removed <- result.result:
                     if !removed.success:

--- a/src/aqua/decider/deal_storage.aqua
+++ b/src/aqua/decider/deal_storage.aqua
@@ -1,6 +1,6 @@
 aqua DealStorage declares *
 
-import Spell from "@fluencelabs/spell/spell_service.aqua"
+import Spell, StringValue from "@fluencelabs/spell/spell_service.aqua"
 
 import FAILED_DEALS, JOINED_DEALS, removed_state_key from "./consts.aqua"
 import Json from "../fluence/peer.aqua"
@@ -15,26 +15,34 @@ data DealState:
 service JsonDealState("json"):
     parse(str: string) -> DealState
 
+func parse_deal_state(spell_id: SpellId, deal_id: string, json: StringValue) -> ?DealState:
+    state: *DealState
+
+    try:
+        state <- JsonDealState.parse(json.value)
+    catch e:
+        deal_log(spell_id, deal_id, ["failed to parse deal state from json", e])
+
+    <- state
+
 func store_deal_state(decider_id: SpellId, deal_id: DealId, state: DealState):
     Spell decider_id
 
     json <- Json.stringify(state)
     Spell.set_string(deal_id, json)
 
-func get_deal_state(decider_id: SpellId, deal_id: string, key: string) -> ?DealState:
-    Spell decider_id
-    state: *DealState
+func get_deal_state(spell_id: SpellId, deal_id: DealId) -> ?DealState:
+    Spell spell_id 
+    state: *?DealState
 
-    json <- Spell.get_string(key)
+    json <- Spell.get_string(deal_id)
     if json.success && !json.absent:
-        try:
-            state <- JsonDealState.parse(json.value)
-        catch e:
-            deal_log(decider_id, deal_id, ["failed to parse deal state (key = ", key, ") from json", e])
+        state <<- parse_deal_state(spell_id, deal_id, json)
     else:
-        deal_log(decider_id, deal_id, ["deal state (key = ", key, ") not found:", json.error])
+        deal_log(spell_id, deal_id, ["deal state not found:", json.error])
+        state <<- nil
 
-    <- state
+    <- state!
 
 func remove_deal_state(spell_id: SpellId, deal_id: DealId):
     Spell spell_id
@@ -49,7 +57,18 @@ func store_deal_state_removed(spell_id: SpellId, deal_id: DealId, left_boundary:
     Spell.set_string(removed_state_key(deal_id), json)
 
 func get_deal_state_removed(spell_id: SpellId, deal_id: DealId) -> ?DealState:
-    <- get_deal_state(spell_id, deal_id, removed_state_key(deal_id))
+    Spell spell_id 
+    state: *?DealState
+
+    key <- removed_state_key(deal_id)
+    json <- Spell.get_string(key)
+    if json.success && !json.absent:
+        state <<- parse_deal_state(spell_id, deal_id, json)
+    else:
+        deal_log(spell_id, deal_id, ["deal removed state not found:", json.error])
+        state <<- nil
+
+    <- state!
 
 func remove_deal_state_removed(spell_id: SpellId, deal_id: DealId):
     Spell spell_id

--- a/src/aqua/decider/deal_storage.aqua
+++ b/src/aqua/decider/deal_storage.aqua
@@ -21,18 +21,18 @@ func store_deal_state(decider_id: SpellId, deal_id: DealId, state: DealState):
     json <- Json.stringify(state)
     Spell.set_string(deal_id, json)
 
-func get_deal_state(decider_id: SpellId, deal_id: DealId) -> ?DealState:
+func get_deal_state(decider_id: SpellId, deal_id: string, key: string) -> ?DealState:
     Spell decider_id
     state: *DealState
 
-    json <- Spell.get_string(deal_id)
+    json <- Spell.get_string(key)
     if json.success && !json.absent:
         try:
             state <- JsonDealState.parse(json.value)
         catch e:
-            deal_log(decider_id, deal_id, ["failed to parse deal state from json", e])
+            deal_log(decider_id, deal_id, ["failed to parse deal state (key = ", key, ") from json", e])
     else:
-        deal_log(decider_id, deal_id, ["deal state not found:", json.error])
+        deal_log(decider_id, deal_id, ["deal state (key = ", key, ") not found:", json.error])
 
     <- state
 
@@ -49,9 +49,7 @@ func store_deal_state_removed(spell_id: SpellId, deal_id: DealId, left_boundary:
     Spell.set_string(removed_state_key(deal_id), json)
 
 func get_deal_state_removed(spell_id: SpellId, deal_id: DealId) -> ?DealState:
-    Spell spell_id
-    key <- removed_state_key(deal_id)
-    <- get_deal_state(spell_id, deal_id)
+    <- get_deal_state(spell_id, deal_id, removed_state_key(deal_id))
 
 func remove_deal_state_removed(spell_id: SpellId, deal_id: DealId):
     Spell spell_id
@@ -97,6 +95,7 @@ func store_deal(spell_id: SpellId, deal_id: DealId, worker_id: WorkerId, block: 
     try:
         store_joined_deal(spell_id, deal_id, worker_id)
         store_deal_state(spell_id, deal_id, DealState(left_boundary = block))
+        store_deal_state_removed(spell_id, deal_id, block)
         deal_log(spell_id, deal_id, "deal state saved to kv")
     catch e:
         deal_log(spell_id, deal_id, ["cannot store deal state, deal join failed", e.message])

--- a/src/aqua/decider/register_worker.aqua
+++ b/src/aqua/decider/register_worker.aqua
@@ -72,8 +72,6 @@ func txs_unknown(spell_id: SpellId) -> []WorkerTxInfo:
 
     all_txs <- Spell.list_get_strings(TXS_KEY)
 
-    spell_log(spell_id, ["all txs", all_txs])
-
     known_txs_statuses  <- Spell.list_get_strings(TXS_STATUS_KEY)
     known_txs: *string
     for status_str <- known_txs_statuses.value:

--- a/src/tests/decider-distro-tests-rs/Cargo.lock
+++ b/src/tests/decider-distro-tests-rs/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "air-interpreter-fs"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "air-interpreter-wasm",
  "blake3",
@@ -225,18 +225,18 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "aqua-ipfs-distro"
-version = "0.5.27"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d578499830da5dac209e76e42ac233cd02249d8f9886ac8459b9dae8cccc1cc"
+checksum = "2acb7726b3147481fe42701baccb0447365def28083c86a188f43ead5f09842b"
 dependencies = [
- "built 0.5.2",
+ "built 0.7.1",
  "maplit",
 ]
 
 [[package]]
 name = "aquamarine"
 version = "0.2.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -793,20 +793,11 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9c056b9ed43aee5e064b683aa1ec783e19c6acec7559e3ae931b7490472fbe"
-dependencies = [
- "cargo-lock 8.0.3",
-]
-
-[[package]]
-name = "built"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99c4cdc7b2c2364182331055623bdf45254fcb679fea565c40c3c11c101889a"
 dependencies = [
- "cargo-lock 9.0.0",
+ "cargo-lock",
 ]
 
 [[package]]
@@ -913,18 +904,6 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
-dependencies = [
- "semver",
- "serde",
- "toml 0.5.11",
- "url",
-]
-
-[[package]]
-name = "cargo-lock"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72"
@@ -1018,7 +997,7 @@ dependencies = [
 [[package]]
 name = "cid-utils"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -1142,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "config-utils"
 version = "0.2.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "libp2p-identity",
 ]
@@ -1150,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "connected-client"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "derivative",
  "either",
@@ -1176,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "connection-pool"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "fluence-libp2p",
  "futures",
@@ -1245,7 +1224,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 [[package]]
 name = "control-macro"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 
 [[package]]
 name = "core-foundation"
@@ -1401,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "created-swarm"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "air-interpreter-fs",
  "aquamarine",
@@ -1603,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "decider-distro"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d747530b3c3c4cc47c0095626c0c74242c1754985f0f3705a6ec243927f6836b"
+checksum = "4c49daae4cc899314717016fbc4a8b9d3467dfaaa75dc2133cdc05d6d3e0257a"
 dependencies = [
  "built 0.7.1",
  "fluence-spell-dtos",
@@ -1615,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "decider-distro"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "built 0.7.1",
  "fluence-spell-dtos",
@@ -1629,7 +1608,7 @@ version = "0.1.0"
 dependencies = [
  "connected-client",
  "created-swarm",
- "decider-distro 0.5.11",
+ "decider-distro 0.5.12",
  "eyre",
  "fluence-app-service",
  "fluence-keypair",
@@ -2096,7 +2075,7 @@ dependencies = [
 [[package]]
 name = "fluence-libp2p"
 version = "0.2.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "base64 0.21.5",
  "bs58",
@@ -2116,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "fluence-spell-distro"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f34514fab80ebdd0c68bc18a9827c299b8a316d12790a1f0525936b363ad9d"
+checksum = "616493945b30a8b2449c94d575b6d3915af11cffda1685396a05e28b5b0dd4e4"
 dependencies = [
  "built 0.7.1",
  "maplit",
@@ -2126,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "fluence-spell-dtos"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b154670a65be0deaf5d461ec94b76009024694ee7752d80dd54d3189901279"
+checksum = "81571565f980f0b8103ec0e231f3cadb5019032a24cb1123b8c11eae0cd6bdcf"
 dependencies = [
  "eyre",
  "marine-rs-sdk",
@@ -2192,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "fs-utils"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "eyre",
  "rand",
@@ -2488,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "health"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "eyre",
 ]
@@ -3176,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "ivalue-utils"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "fluence-it-types",
  "serde_json",
@@ -3203,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "json-utils"
 version = "0.0.2"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "base64 0.21.5",
  "itertools 0.12.0",
@@ -3304,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "kademlia"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "bs58",
  "control-macro",
@@ -3342,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "key-manager"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "eyre",
  "fluence-keypair",
@@ -3975,7 +3954,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 [[package]]
 name = "local-vm"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "air-interpreter-fs",
  "air-interpreter-wasm",
@@ -4019,7 +3998,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "log-utils"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "console-subscriber",
  "log",
@@ -4718,12 +4697,12 @@ dependencies = [
 [[package]]
 name = "now-millis"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 
 [[package]]
 name = "nox"
-version = "0.16.11"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+version = "0.16.12"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "air-interpreter-fs",
  "air-interpreter-wasm",
@@ -5089,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "particle-args"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "avm-server",
  "bs58",
@@ -5105,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "particle-builtins"
 version = "0.2.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "async-trait",
  "avm-server",
@@ -5151,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "particle-execution"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "async-trait",
  "fluence-app-service",
@@ -5170,7 +5149,7 @@ dependencies = [
 [[package]]
 name = "particle-modules"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "base64 0.21.5",
  "bytesize",
@@ -5198,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "particle-protocol"
 version = "0.3.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "base64 0.21.5",
@@ -5225,7 +5204,7 @@ dependencies = [
 [[package]]
 name = "particle-services"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "derivative",
  "eyre",
@@ -5281,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "peer-metrics"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "bytesize",
  "fluence-app-service",
@@ -6332,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "server-config"
 version = "0.2.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "air-interpreter-fs",
  "base64 0.21.5",
@@ -6364,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "service-modules"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "cid-utils",
  "eyre",
@@ -6542,7 +6521,7 @@ dependencies = [
 [[package]]
 name = "sorcerer"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "aquamarine",
  "connection-pool",
@@ -6581,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "spell-event-bus"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "connection-pool",
  "derivative",
@@ -6609,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "spell-service-api"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "fluence-libp2p",
  "fluence-spell-dtos",
@@ -6624,7 +6603,7 @@ dependencies = [
 [[package]]
 name = "spell-storage"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "derivative",
  "eyre",
@@ -6689,7 +6668,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "subnet-resolver"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "ethabi",
  "eyre",
@@ -6788,10 +6767,10 @@ dependencies = [
 [[package]]
 name = "system-services"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "aqua-ipfs-distro",
- "decider-distro 0.5.9",
+ "decider-distro 0.5.11",
  "eyre",
  "fluence-app-service",
  "fluence-spell-dtos",
@@ -6855,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "test-constants"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 
 [[package]]
 name = "textwrap"
@@ -7059,7 +7038,7 @@ dependencies = [
 [[package]]
 name = "toml-utils"
 version = "0.0.1"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "toml 0.5.11",
 ]
@@ -7187,7 +7166,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "toy-vms"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "aquamarine",
  "avm-server",
@@ -7294,9 +7273,9 @@ dependencies = [
 
 [[package]]
 name = "trust-graph-distro"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ab6f5421a91eb20205c2a7ec93c428b278c45b45a3860f412f0890c9439d5"
+checksum = "e30db708eed6fd29b4cc3e3f72b2979e65d758145d8b6538bbd9f55f9e8fb018"
 dependencies = [
  "built 0.6.1",
  "lazy_static",
@@ -7452,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "uuid-utils"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.11#967824bfd6d3ea9e5582b4263a72ca7112244e6f"
+source = "git+https://github.com/fluencelabs/nox.git?tag=nox-v0.16.12#d64a80e215bc42dca7b5df5e31e8bc152b1a1a22"
 dependencies = [
  "uuid",
 ]

--- a/src/tests/decider-distro-tests-rs/tests/test_remove.rs
+++ b/src/tests/decider-distro-tests-rs/tests/test_remove.rs
@@ -196,6 +196,7 @@ async fn test_remove_deal_from_provider() {
                 2,
                 "expected two topics: topic and host_id"
             );
+            assert!(log.from_block <= LATEST_BLOCK);
             server.send_response(Ok(removed_event));
         }
     }
@@ -244,8 +245,6 @@ async fn test_deal_ended_and_removed_from_provider() {
         format!("0x{}", DEAL_ID),
         "decider should join exactly one deal"
     );
-
-    println!("run again");
 
     // run again with both deal status ENDED and remove from provider event
     update_config(&mut client, &oneshot_config()).await.unwrap();

--- a/src/tests/decider-distro-tests-rs/tests/utils/state/deal.rs
+++ b/src/tests/decider-distro-tests-rs/tests/utils/state/deal.rs
@@ -27,7 +27,6 @@ pub async fn get_deal_state(client: &mut ConnectedClient, deal_id: &str) -> Deal
 
 pub async fn get_deal_removed_state(client: &mut ConnectedClient, deal_id: &str) -> DealState {
     let key = format!("removed_state:0x{deal_id}");
-    println!("key: {key}");
     let result = spell::get_string(client, "decider", &key)
         .await
         .wrap_err("getting deal state")

--- a/src/tests/decider-distro-tests-rs/tests/utils/state/deal.rs
+++ b/src/tests/decider-distro-tests-rs/tests/utils/state/deal.rs
@@ -9,8 +9,26 @@ pub struct DealState {
     pub left_boundary: String,
 }
 
-pub async fn get_deal_state(client: &mut ConnectedClient, deal_id: &String) -> DealState {
+pub async fn get_deal_state(client: &mut ConnectedClient, deal_id: &str) -> DealState {
     let result = spell::get_string(client, "decider", deal_id)
+        .await
+        .wrap_err("getting deal state")
+        .unwrap();
+    assert!(!result.absent, "no state for deal {}", deal_id);
+    assert!(
+        result.success,
+        "can't get state for deal {}: {}",
+        deal_id, result.error
+    );
+    serde_json::from_str::<DealState>(&result.value)
+        .wrap_err("parse deal_state")
+        .unwrap()
+}
+
+pub async fn get_deal_removed_state(client: &mut ConnectedClient, deal_id: &str) -> DealState {
+    let key = format!("removed_state:0x{deal_id}");
+    println!("key: {key}");
+    let result = spell::get_string(client, "decider", &key)
         .await
         .wrap_err("getting deal state")
         .unwrap();

--- a/src/tests/decider-distro-tests-rs/tests/utils/state/decider.rs
+++ b/src/tests/decider-distro-tests-rs/tests/utils/state/decider.rs
@@ -19,3 +19,17 @@ pub async fn get_sync_info(client: &mut ConnectedClient) -> eyre::Result<SyncInf
 
     serde_json::from_str::<SyncInfo>(&result.value).wrap_err("parse sync_info")
 }
+
+pub async fn get_last_seen(client: &mut ConnectedClient) -> eyre::Result<Option<String>> {
+    let result = spell::get_string(client, "decider", "last_seen_block")
+        .await
+        .wrap_err("get last_seen_block failed")?;
+    if !result.success {
+        return Err(eyre::eyre!("get sync_info failed: {}", result.error));
+    }
+    Ok(if result.absent {
+        None
+    } else {
+        Some(result.value)
+    })
+}


### PR DESCRIPTION
Found a bug that the decider can't find the removed-from-provider event. After prolonged debugging, I found that decider uses the state from deal-update event polling, not from deal-removed-from-provider. Fixed it, also improved tests to detect that from_block is strange.